### PR TITLE
Added test cases for typical german equivalences & dictionary fallback.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,8 @@ mod tests {
         assert!(similar("jumpo", "jumbo"));
         assert!(similar("lol", "lulz"));
         assert!(similar("goth", "god"));
+        assert!(similar("maier", "meyer"));
+        assert!(similar("schmid", "schmidt"));
 
         // Not similar.
         assert!(!similar("youtube", "reddit"));
@@ -205,7 +207,9 @@ mod tests {
         use std::io::{BufRead, BufReader};
 
         b.iter(|| {
-            let dict = fs::File::open("/usr/share/dict/american-english").unwrap();
+            let dict = fs::File::open("/usr/share/dict/american-english").unwrap_or_else(|_| {
+                fs::File::open("/usr/share/dict/words").unwrap()
+            });
             let mut vec = Vec::new();
 
             for i in BufReader::new(dict).lines() {


### PR DESCRIPTION
Added exemplary test cases for typical german equivalences (variants of german surnames) and a dictionary fallback for when there exists no /usr/share/dict/american-english on your system, such as OS X.

Second attempt after PR #1 failed on me.
