### PR TITLE
change | to || in if expression to allow short-circuiting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@ pub fn hash(string: &str) -> u64 {
     loop {
         b += 1;
         // Detect overflows into the first slot.
-        if (n == 0) | (b >= string.len()) {
+        if n == 0 || b >= string.len() {
             break;
         }
 


### PR DESCRIPTION
This is really minor, but [according to the reference](https://doc.rust-lang.org/reference.html#lazy-boolean-operators) `bool | bool` does not short-circuit, while `bool || bool` does.
