### PR TITLE
Make hash field public so a hash can be created from u64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod tests;
 /// Using the `Sub` implementation of the hashes will give you the difference.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Hash {
-    hash: u64,
+    pub hash: u64,
 }
 
 impl Hash {


### PR DESCRIPTION
Is there currently any way of persisting a Hash value? It is simple enough to persist and load the u64 internal value, but I was wondering if there was something more idiomatic that I am missing.